### PR TITLE
Remove wget from Linux requisites - issue 118

### DIFF
--- a/README
+++ b/README
@@ -69,7 +69,7 @@ Mac comes with everything needed to run Prey. However Linux users should make
 sure they have the following installed: (note the installer does this
 automatically!)
 
-	o curl / wget
+	o curl
 	o scrot or imagemagick (for screenshot capture)
 	o streamer (for webcam capture) --> in Fedora the xawtv package includes it
 	o Perl libs IO::Socket::SSL and NET::SSLeay


### PR DESCRIPTION
Remove wget from Linux requisites - it isn't used by Linux Prey. curl cannot be easily switched out for wget - see https://github.com/tomas/prey/issues/118
