### PR TITLE
Fix colors on Mac OS X

### DIFF
--- a/core/setup
+++ b/core/setup
@@ -117,10 +117,10 @@ set_constants(){
 }
 
 set_colors(){
-	cyan='\E[36m'
-	green='\E[32m'
-	red='\E[31m'
-	color_end='\E[0m'
+	cyan='\033[36m'
+	green='\033[32m'
+	red='\033[31m'
+	color_end='\033[0m'
 	bold='\033[1m'
 	bold_end='\033[0m'
 }


### PR DESCRIPTION
Mac's Bash doesn't seem to be handing \E but \033 works ok.
