### PR TITLE
Basic Lion support for pc_os_settings

### DIFF
--- a/platform/mac/settings
+++ b/platform/mac/settings
@@ -20,7 +20,9 @@ get_osx_version(){
 
 	local pc_os_number=`sw_vers -productVersion | cut -c1-4`
 
-	if [[ $pc_os_number == "10.6" || `is_greater_than "$pc_os_number" 10.6` == 1 ]]; then
+	if [[ $pc_os_number == "10.7" || `is_greater_than "$pc_os_number" 10.7` == 1 ]]; then
+		osx_version="lion"
+	elif [[ $pc_os_number == "10.6" || `is_greater_than "$pc_os_number" 10.6` == 1 ]]; then
 		osx_version="snow-leopard"
 	elif [[ $pc_os_number == "10.5" || `is_greater_than "$pc_os_number" 10.5` == 1 ]]; then
 		osx_version="leopard"


### PR DESCRIPTION
Simply added Lion/10.7 support into the version checker.
