### PR TITLE
Added support for multiple reporting methods, e.g. email and http

### DIFF
--- a/config
+++ b/config
@@ -23,7 +23,8 @@ check_url='http://control.preyproject.com'
 missing_status_code='404'
 
 # you can use send the report via email or to the web service
-# valid values: http, email, scp or sftp
+# valid values: http, email, scp or sftp or a combination of those
+# separated by spaces, e.g. 'http email'
 post_method='http'
 
 ####################################################################

--- a/config.default
+++ b/config.default
@@ -23,7 +23,8 @@ check_url='http://control.preyproject.com'
 missing_status_code='404'
 
 # you can use send the report via email or to the web service
-# valid values: http, email, scp or sftp
+# valid values: http, email, scp or sftp or a combination of those
+# separated by spaces, e.g. 'http email'
 post_method='http'
 
 ####################################################################

--- a/core/functions
+++ b/core/functions
@@ -154,7 +154,7 @@ add_file(){
 list_files(){
 	# log " -- ${#files[*]} files gathered!"
 	for f in "${files[@]}"; do
-		if [ "$post_method" == 'http' ]; then
+		if [[ "$post_method" == *http* ]]; then
 			# echo -e "-F $f" | sed -e 's/=/=@/'
 			echo "-F $f" | sed 's/^\([^_].*\)__\([^=].*\)=\(.*\)/\1[\2]=@\3/'
 		else # just list the file paths

--- a/core/modules
+++ b/core/modules
@@ -88,7 +88,7 @@ set_module_paths_for(){
 
 run_active_modules() {
 
-	if [[ -z $active_modules && "$post_method" != 'http' ]]; then
+	if [[ -z $active_modules && "$post_method" != *http* ]]; then
 		get_active_modules_from_filesystem
 	fi
 

--- a/core/pull
+++ b/core/pull
@@ -36,7 +36,7 @@ randomize_subdomain(){
 
 # we could eventually use a different method for status checking
 check_device_status(){
-	#if [ "$post_method" == 'http' ]; then
+	#if [[ "$post_method" == *http* ]]; then
 		request_headers="-H X-Encrypt-Response:${cipher_algorithm}"
 
 		if [ -n "$device_key" ]; then

--- a/core/push
+++ b/core/push
@@ -38,7 +38,7 @@ deactivate_modules_on_panel(){
 
 send_report(){
 	log ' -- Packing all gathered traces...'
-	[ "$post_method" == "http" ] && trace_list=$(generate_query_string 'traces') || trace_list=$(generate_list 'traces')
+	[[ "$post_method" == *http* ]] && trace_list=$(generate_query_string 'traces') || trace_list=$(generate_list 'traces')
 	file_list=$(list_files)
 	if [[ $trace_list || $file_list ]]; then
 			if [ -n "$test_mode" ]; then
@@ -46,8 +46,10 @@ send_report(){
 			else
 				trace_file="$tmpdir/prey_traces.tmp"
 				echo -e "$trace_list" > "$trace_file"
-				log " -- Posting data via $post_method..."
-				eval 'send_via_'"${post_method}"''
+				for i in $post_method; do
+					log " -- Posting data via $i..."
+					eval 'send_via_'"${i}"''
+				done
 				local rs=$?
 				rm -f "$trace_file" 2> /dev/null
 			fi

--- a/platform/linux/prey-config.py
+++ b/platform/linux/prey-config.py
@@ -368,7 +368,7 @@ class PreyConfigurator(object):
 		self.get('smtp_server').set_text(self.current_smtp_server)
 		self.get('smtp_username').set_text(self.current_smtp_username)
 
-		if self.current_post_method == 'email':
+		if 'email' in self.current_post_method and 'http' not in self.current_post_method:
 			self.get('reporting_mode_standalone').set_active(True)
 
 	def check_if_configured(self):
@@ -423,8 +423,8 @@ class PreyConfigurator(object):
 
 	def apply_control_panel_settings(self):
 
-		if self.current_post_method != 'http':
-			self.save_setting('post_method', 'http')
+		if 'http' not in self.current_post_method:
+			self.save_setting('post_method', (post_method + ' http').strip())
 
 		if self.current_check_url != CONTROL_PANEL_URL:
 			self.save_setting('check_url', CONTROL_PANEL_URL)
@@ -439,8 +439,8 @@ class PreyConfigurator(object):
 
 	def apply_standalone_settings(self):
 
-		if self.current_post_method != 'email':
-			self.save_setting('post_method', 'email')
+		if 'email' not in self.current_post_method:
+			self.save_setting('post_method', (post_method + ' email').strip())
 
 		self.save_setting('check_url', self.text('check_url'))
 		self.save_setting('mail_to', self.text('mail_to'))

--- a/prey.sh
+++ b/prey.sh
@@ -87,10 +87,11 @@ if [ -n "$check_mode" ]; then
 	log "\n${bold} == Verifying Prey installation...${bold_end}\n"
 	verify_installation
 
-	if [ "$post_method" == "http" ]; then
+	if [[ "$post_method" == *http* ]]; then
 		log "\n${bold} == Verifying API and Device keys...${bold_end}\n"
 		verify_keys
-	elif [ "$post_method" == "email" ]; then
+	fi
+	if [[ "$post_method" == *email* ]]; then
 		log "\n${bold} == Verifying SMTP settings...${bold_end}\n"
 		verify_smtp_settings
 	fi
@@ -105,7 +106,7 @@ fi
 ####################################################################
 
 # only do this if Prey is being run from cron in Mac and Linux
-if [[ "$os" != "windows" && -n "$(running_from_cron)" && "$post_method" == "http" ]]; then
+if [[ "$os" != "windows" && -n "$(running_from_cron)" && "$post_method" == *http* ]]; then
 	seconds_to_wait=$(get_random_number 59)
 	log " -- Pausing for ${seconds_to_wait} seconds..."
 	sleep $seconds_to_wait


### PR DESCRIPTION
Hi Tomás,

I think the best way to report is to report in all possible ways, so I've changed the code the bit to allow multiple reporting methods to be used. Also 1 minor fix on how the encrypted SMTP password is decrypted and a medium fix for the fact that retrieving the device status checks the reporting method, which I think is wrong and failed when using something else than 'http' for post_method.

Hope it helps!
Jeroen  
