### PR TITLE
Make sure prey.sh is only ever run as root

### DIFF
--- a/prey.sh
+++ b/prey.sh
@@ -5,6 +5,17 @@
 # License: GPLv3
 ####################################################################
 
+
+####################################################################
+# Prey should always be run as root. If not, it messes up logging to
+# /var/log/prey.log and crontabs
+####################################################################
+
+if [ "$(id -u)" != "0" ]; then
+   echo "ERROR: Prey.sh must be run as root (sudo ./prey.sh)" 1>&2
+   exit 1
+fi
+
 PATH=/bin:/sbin:/usr/bin:/usr/sbin:$PATH
 readonly base_path=$(dirname "$0")
 


### PR DESCRIPTION
Earlier today I ran `./prey.sh` not as root. This messed up things as it installed a cron for my user (not root) which subsequently failed (noisily) every time it was run (since writing to /var/log/prey.log was failing with permission denied)

It's also quite misleading being able to run `./prey.sh --check`
It seemingly works fie, but confusingly notifies you that the cron is missing and you should install it (because it's actually set for root, not the current user)
