### PR TITLE
Fix invalid SSL_Version Error for SendEmail

### DIFF
--- a/platform/linux/bin/sendEmail
+++ b/platform/linux/bin/sendEmail
@@ -1912,7 +1912,7 @@ else {
     if ($conf{'tls_server'} == 1 and $conf{'tls_client'} == 1 and $opt{'tls'} =~ /^(yes|auto)$/) {
         printmsg("DEBUG => Starting TLS", 2);
         if (SMTPchat('STARTTLS')) { quit($conf{'error'}, 1); }
-        if (! IO::Socket::SSL->start_SSL($SERVER, SSL_version => 'SSLv3 TLSv1')) {
+        if (! IO::Socket::SSL->start_SSL($SERVER, SSL_version => 'SSLv3')) {
             quit("ERROR => TLS setup failed: " . IO::Socket::SSL::errstr(), 1);
         }
         printmsg("DEBUG => TLS: Using cipher: ". $SERVER->get_cipher(), 3);


### PR DESCRIPTION
Remove TLSv1 as it causes SSL errors due to it being disabled on numerous sites preventing emails from being successfully sent.

See issue #410 
